### PR TITLE
Improved use instructions, Steam Sniper and Proton-GE version bumps, added .desktop file, handling .CLIP files from file managers

### DIFF
--- a/Clip_Studio_Paint.desktop
+++ b/Clip_Studio_Paint.desktop
@@ -1,0 +1,7 @@
+[Desktop Entry]
+Name=Clip Studio Paint
+Comment=Clip Studio Paint
+Exec=/home/devovas/.local/share/csp-linux/launch/csp-linux %f
+Icon=/home/devovas/.local/share/csp-linux/csp.png
+Terminal=false
+Type=Application

--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@ This is a script to install Clip Studio Paint on Linux using the help of Valve's
 ## Dependencies
 - wget
 - pv
+- winepath (part of wine, without it CSP won't open .CLIP files from your file manager)
 
-Arch Linux users can install them with `pacman -S wget pv`
+Arch Linux users can install them with `pacman -S wget pv wine`
 
 ## Installation (It's that easy!)
 ```bash
@@ -15,10 +16,21 @@ chmod +x csp-installer.sh
 ./csp-installer.sh 3
 ```
 
-Once it's installed, you can start CSP by running `csp-linux` in your terminal.
+Once it's installed, find how to add `~/.local/share/csp-linux/launch` to your
+bash PATH, so you can use csp-linux to start CSP.  
+If you use a different shell, like fish or zsh, find instructions for that
+shell.  
+Even without that, some desktop environments like KDE will still find Clip
+Studio Paint and it'll appear in the program launcher.  
 
 ## Uninstallation
 To uninstall CSP, run `./csp-installer.sh uninstall`, or delete `~/.local/share/csp-linux`
 & `~/.config/csprc` from your machine manually.
 
-## Made with love ❤️ by minsiam
+## Extra
+If you use KDE, you can add a plugin to show .CLIP thumbnails, follow [this guide.](https://www.reddit.com/r/ClipStudio_on_Linux/comments/1pv8tft/clip_studio_kde_plugins_by_joshua_goins/)  
+Besides Fedora users, SUSE users can also use the pre-built pacakges by
+downloading them [from here.](https://copr.fedorainfracloud.org/coprs/redstrate/personal/package/clipstudio-kde/)  
+Click on the latest Build ID, then on the folder under Chroot Name, and click on the file named `clipstudio-kde-<VERSION>.x86_64.rpm`,
+
+## Made with love ❤️ 

--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ cd csp-linux
 chmod +x csp-installer.sh
 ./csp-installer.sh 3
 ```
-
-Once it's installed, find how to add `~/.local/share/csp-linux/launch` to your
-bash PATH, so you can use csp-linux to start CSP.  
+To launch CSP without having to return to the `csp-linux` folder every time,
+find how to add `~/.local/share/csp-linux/launch` to your bash PATH, so you can
+use csp-linux to start CSP.  
 If you use a different shell, like fish or zsh, find instructions for that
 shell.  
 Even without that, some desktop environments like KDE will still find Clip

--- a/csp-installer.sh
+++ b/csp-installer.sh
@@ -15,12 +15,13 @@ EOF
 }
 
 # Check if the script is run on a supported platform
-if [[ "$OSTYPE" != "linux-gnu" ]]; then
+if [[ "$OSTYPE" != "linux" ]] && [[ "$OSTYPE" != "linux-gnu" ]]; then
     echo "This script is only supported on Linux" 1>&2
     exit 1
 fi
 
 export CSP_PATH=/home/$USER/.local/share/csp-linux
+export APPLICATIONS_PATH=/home/$USER/.local/share/applications
 
 # Check there is exactly 1 argument
 if [ "$#" -ne 1 ]; then
@@ -87,9 +88,23 @@ else
         exit 1
     fi
 
+    # Check if winepath is installed
+    if ! command -v winepath &>/dev/null; then
+        echo "Please install winepath (usually part of wine) or CSP won't be able to open files from your file manager." 1>&2
+    fi
+
     if [ ! -d $CSP_PATH ]; then
         mkdir $CSP_PATH
     fi
+
+    if [ ! -d $APPLICATIONS_PATH ]; then
+        mkdir -p $APPLICATIONS_PATH;
+    fi
+
+    cp Clip_Studio_Paint.desktop $APPLICATIONS_PATH
+    mkdir "${CSP_PATH}/launch"
+    cp csp-linux "${CSP_PATH}/launch"
+    wget "https://upload.wikimedia.org/wikipedia/en/6/66/Clip_Studio_Paint_app_logo.png" -O "${APPLICATIONS_PATH}/csp.png"
 
     cd $CSP_PATH
 
@@ -99,23 +114,23 @@ else
     fi
 
     # Install Proton
-    if [ ! -d GE-Proton9-20 ]; then
-        if [ ! -f "GE-Proton9-20.tar.gz" ]; then
-            echo "Downloading GE-Proton 9-20..."
-            wget -q --show-progress "https://github.com/GloriousEggroll/proton-ge-custom/releases/download/GE-Proton9-20/GE-Proton9-20.tar.gz"
+    if [ ! -d GE-Proton10-28 ]; then
+        if [ ! -f "GE-Proton10-28.tar.gz" ]; then
+            echo "Downloading GE-Proton 10-28..."
+            wget -q --show-progress "https://github.com/GloriousEggroll/proton-ge-custom/releases/download/GE-Proton10-28/GE-Proton10-28.tar.gz"
         fi
 
-        echo "Extracting GE-Proton 9-20..."
-        pv "GE-Proton9-20.tar.gz" | tar -xvz >/dev/null
-        echo Removing GE-Proton 9-20.tar.gz...
-        rm GE-Proton9-20.tar.gz
+        echo "Extracting GE-Proton 10-28..."
+        pv "GE-Proton10-28.tar.gz" | tar -xvz >/dev/null
+        echo Removing GE-Proton 10-28.tar.gz...
+        rm GE-Proton10-28.tar.gz
     fi
 
     # Install steam-container-runtime
     if [ ! -d steam-container-runtime ]; then
         if [ ! -f "steam-container-runtime.tar.gz" ]; then
             echo "Downloading steamrt..."
-            wget -q --show-progress "https://repo.steampowered.com/steamrt-images-sniper/snapshots/0.20220119.0/steam-container-runtime.tar.gz"
+            wget -q --show-progress "https://repo.steampowered.com/steamrt-images-sniper/snapshots/0.20240125.75305/steam-container-runtime.tar.gz"
         fi
 
         pv steam-container-runtime.tar.gz | tar -xvz >/dev/null
@@ -166,14 +181,14 @@ else
     export STEAM_COMPAT_DATA_PATH="$(realpath csp-pfx)"
 
     echo "Setting Windows version to win81..."
-    "GE-Proton9-20/proton" run winecfg -v win81
+    "GE-Proton10-28/proton" run winecfg -v win81
     if [ $? -ne 0 ]; then
         echo "Failed to set Windows version to win81"
         exit 1
     fi
     echo "Starting installer..."
     echo "Go through the process as you usually would then press enter (on terminal) to finish"
-    "GE-Proton9-20/proton" run "$CSP_SETUP"
+    "GE-Proton10-28/proton" run "$CSP_SETUP"
 
     while true; do
         read -r -n 1 key
@@ -188,14 +203,15 @@ else
 
     cat << EOF >>/home/$USER/.config/csprc
 [Proton]
-PROTON_PATH=$CSP_PATH/GE-Proton9-20
+PROTON_PATH=$CSP_PATH/GE-Proton10-28
 STEAM_COMPAT_DATA_PATH=$STEAM_COMPAT_DATA_PATH
 STEAM_COMPAT_CLIENT_INSTALL_PATH=$STEAM_COMPAT_CLIENT_INSTALL_PATH
 EOF
 
     echo "CSP is now installed!"
-    echo "Run csp-linux to start CSP"
+    echo "Find how to add ${CSP_PATH}/launch to your bash PATH, so you can use csp-linux to start CSP."
+    echo "If you use a different shell, like fish or zsh, find instructions for that shell."
+    echo "Even without that, some desktop environments like KDE will still find Clip Studio Paint and it'll appear in the program launcher."
 
     rm "$CSP_SETUP"
 fi
-

--- a/csp-installer.sh
+++ b/csp-installer.sh
@@ -52,6 +52,14 @@ elif [ $1 = "uninstall" ]; then
         fi
     fi
 
+    if [ -f $APPLICATIONS_PATH/Clip_Studio_Paint.desktop ]; then
+        rm $APPLICATIONS_PATH/Clip_Studio_Paint.desktop $APPLICATIONS_PATH/csp.png
+        if [ $? -ne 0 ]; then
+            echo "Failed to remove $APPLICATIONS_PATH/Clip_Studio_Paint.desktop" 1>&2
+            exit 1
+        fi
+    fi
+
     echo "Successfully removed CSP"
     exit 0
 else

--- a/csp-linux
+++ b/csp-linux
@@ -1,8 +1,8 @@
 #!/usr/bin/bash
 
-CSP_PATH="`winepath --windows \"$1\"`"
+CLIP_PATH="`winepath --windows \"$1\"`"
 
-echo $CSP_PATH
+echo $CLIP_PATH
 export PROTON_PATH=$(cat ~/.config/csprc | grep PROTON_PATH | cut -d '=' -f 2)
 echo $PROTON_PATH
 export STEAM_COMPAT_DATA_PATH=$(cat ~/.config/csprc | grep STEAM_COMPAT_DATA_PATH | cut -d '=' -f 2)
@@ -16,10 +16,10 @@ if [ $? -ne 0 ]; then
 fi
 
 echo "Starting CSP..."
-if [ -z "$CSP_PATH" ]
+if [ -z "$CLIP_PATH" ]
 then
     $PROTON_PATH/proton run $STEAM_COMPAT_DATA_PATH/pfx/drive_c/Program\ Files/CELSYS/CLIP\ STUDIO\ 1.5/CLIP\ STUDIO\ PAINT/CLIPStudioPaint.exe
 else
-    $PROTON_PATH/proton run $STEAM_COMPAT_DATA_PATH/pfx/drive_c/Program\ Files/CELSYS/CLIP\ STUDIO\ 1.5/CLIP\ STUDIO\ PAINT/CLIPStudioPaint.exe "$CSP_PATH"
+    $PROTON_PATH/proton run $STEAM_COMPAT_DATA_PATH/pfx/drive_c/Program\ Files/CELSYS/CLIP\ STUDIO\ 1.5/CLIP\ STUDIO\ PAINT/CLIPStudioPaint.exe "$CLIP_PATH"
 fi
 

--- a/csp-linux
+++ b/csp-linux
@@ -1,3 +1,8 @@
+#!/usr/bin/bash
+
+CSP_PATH="`winepath --windows \"$1\"`"
+
+echo $CSP_PATH
 export PROTON_PATH=$(cat ~/.config/csprc | grep PROTON_PATH | cut -d '=' -f 2)
 echo $PROTON_PATH
 export STEAM_COMPAT_DATA_PATH=$(cat ~/.config/csprc | grep STEAM_COMPAT_DATA_PATH | cut -d '=' -f 2)
@@ -11,4 +16,10 @@ if [ $? -ne 0 ]; then
 fi
 
 echo "Starting CSP..."
-$PROTON_PATH/proton run $STEAM_COMPAT_DATA_PATH/pfx/drive_c/Program\ Files/CELSYS/CLIP\ STUDIO\ 1.5/CLIP\ STUDIO\ PAINT/CLIPStudioPaint.exe
+if [ -z "$CSP_PATH" ]
+then
+    $PROTON_PATH/proton run $STEAM_COMPAT_DATA_PATH/pfx/drive_c/Program\ Files/CELSYS/CLIP\ STUDIO\ 1.5/CLIP\ STUDIO\ PAINT/CLIPStudioPaint.exe
+else
+    $PROTON_PATH/proton run $STEAM_COMPAT_DATA_PATH/pfx/drive_c/Program\ Files/CELSYS/CLIP\ STUDIO\ 1.5/CLIP\ STUDIO\ PAINT/CLIPStudioPaint.exe "$CSP_PATH"
+fi
+


### PR DESCRIPTION
Hello! It's technically not good practice to push all these changes in a single pull request, but I'm porting the changes after I made them on my system, and considering the kind of repo I think we're can get away with this hehe  

My changes are:  
+ Added a missing shebang to the `csp-linux` script.  
+ Fixed the OS detection, OpenSUSE outputs `linux` instead of `linux-gnu`, and the script now accepts both.  
+ Specified in the readme that, in order to launch Clip Studio Paint with the `csp-linux` command, the user needs to be in the folder of the repo, or otherwise add a path with the script to their `PATH` environment variable.  
+ Bumped versions for the Steam Sniper container runtime and for Proton-GE to their current latest versions, they may have bug fixes and performance improvements, and they appear to work fine on both OpenSUSE Tumbleweed and Arch Linux.
+ Added a .desktop file so that desktop environments can find and launch CSP from their application launchers.  
+ Changed the csp-linux script so it can handle files as arguments and open them. This added an optional dependency to wine/winepath, without it the script will still run.  
+ Added info regarding a thumbnail plugin for KDE in the readme.  
+ Replaced the acknowledgment at the end with just "Made with love", since this repo has received many crucial contributions from other people before me and it wouldn't be fair to have a single acknowledgment, while updating it to add new names every time would be a pain. I hope you won't mind!  